### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Customsearches/Form/Search/agSpam.php
+++ b/CRM/Customsearches/Form/Search/agSpam.php
@@ -251,7 +251,7 @@ END_SQL;
       $clauses [] = "(contact_a.id > $min_contact_id)";
     }
 
-    $blank_names = CRM_Utils_Array::value('blank_names', $this->_formValues);
+    $blank_names = $this->_formValues['blank_names'] ?? NULL;
     if ($blank_names) {
       $clauses [] = "(contact_a.first_name AND contact_a.last_name)";
     }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.